### PR TITLE
Debug support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       ],
       "outFiles": [
         "${workspaceFolder}/out"
-      ]
+      ],
+      "preLaunchTask": "npm: build"
     }
   ]
 }

--- a/src/cmake-runner.ts
+++ b/src/cmake-runner.ts
@@ -206,8 +206,8 @@ export function executeCmakeDebug(
           );
           const cwd = WORKING_DIRECTORY ? WORKING_DIRECTORY.value as string : undefined;
           let workspaceFolder = undefined;
-          if (typeof cwd === 'string') {
-            workspaceFolder = workspace.workspaceFolders?.find(folder => folder.uri.fsPath.indexOf(cwd) > -1);
+          if (typeof cwd === 'string' && Array.isArray(workspace.workspaceFolders)) {
+            workspaceFolder = workspace.workspaceFolders.find(folder => folder.uri.fsPath.indexOf(cwd) > -1);
           }
           debug.startDebugging(workspaceFolder, {
             name: '(gdb) Launch',


### PR DESCRIPTION
Hi there,

We're currently using this test adapter but needed debugging support. I've tried to avoid disturbing too much of the codebase, so I'm piggybacking much of the runner code. This does mean there's some code duplication in there as I started with a copy of the `executeCmakeRun` function, but again I didn't want to trample on too much.

It appears to work as we expect it to when deployed but that's as far I've gone on testing. If I've missed unit tests or similar that need updating, let me know!

I've also added a pre-launch build step to the launch config as debugging the plugin was otherwise giving me some funny results. Happy to remove if that breaks something elsewhere for you.

Cheers