### PR TITLE
Contextual variables in settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       ],
       "outFiles": [
         "${workspaceFolder}/out"
-      ]
+      ],
+      "preLaunchTask": "npm: build"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.23.0.tgz",
-      "integrity": "sha512-gMIEQTtt84M2PglQ8pmuanc9I8TZIHkK9bWz8teandxZX5o+gGGdbt0bfA5OMtotDqf3Ni+iRW5YaZCJFzJ07A==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.31.0.tgz",
+      "integrity": "sha512-uUpjvtrQ14ZEqqRE/EGuBvGbm9GuxDp76mtsnw3goMogsWmEEYS/y4eL2Zwf0rbFMh/hg3hEs+E3CvuuNEs+GA==",
       "dev": true
     },
     "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "vscode-test-adapter-util": "^0.7.0"
   },
   "devDependencies": {
-    "@types/vscode": "~1.23.0",
+    "@types/vscode": "~1.31.0",
     "typescript": "^3.5.3",
     "vsce": "^1.65.0"
   },
   "engines": {
-    "vscode": "^1.23.0"
+    "vscode": "^1.31.0"
   },
   "extensionDependencies": [
     "hbenl.vscode-test-explorer"
@@ -66,6 +66,12 @@
           "description": "The CMake build configuration (empty for any)",
           "type": "string",
           "default": "",
+          "scope": "resource"
+        },
+        "cmakeExplorer.cmakeIntegration": {
+          "description": "Integrate with the CMake VSCode extension to provide contextual awareness",
+          "type": "boolean",
+          "default": "false",
           "scope": "resource"
         },
         "cmakeExplorer.extraCtestLoadArgs": {

--- a/src/cmake-adapter.ts
+++ b/src/cmake-adapter.ts
@@ -102,9 +102,9 @@ export class CmakeAdapter implements TestAdapter {
         'cmakeExplorer',
         this.workspaceFolder.uri
       );
-      buildDir = config.get<string>('buildDir') || '';
-      const buildConfig = config.get<string>('buildConfig') || '';
-      const extraCtestLoadArgs = config.get<string>('extraCtestLoadArgs') || '';
+      buildDir = await this.configGetStr(config, 'buildDir');
+      const buildConfig = await this.configGetStr(config, 'buildConfig');
+      const extraCtestLoadArgs = await this.configGetStr(config, 'extraCtestLoadArgs');
       const dir = path.resolve(this.workspaceFolder.uri.fsPath, buildDir);
       this.ctestPath = getCtestPath(dir);
       this.cmakeTests = await loadCmakeTests(
@@ -277,5 +277,26 @@ export class CmakeAdapter implements TestAdapter {
     } finally {
       this.currentTest = undefined;
     }
+  }
+
+  configGetStr(config: vscode.WorkspaceConfiguration, key: string) {
+    const item = config.get<string>(key) || '';
+    return this.substituteConfigStr(item);
+  }
+
+  async substituteConfigStr(configStr: string) {
+    const substitutionMap = new Map<string, string>([
+      ['${workspaceFolder}', this.workspaceFolder.uri.fsPath],
+    ]);
+    if ((await vscode.commands.getCommands()).includes('cmake.buildType')) {
+      substitutionMap.set('${buildType}', await vscode.commands.executeCommand('cmake.buildType') as string);
+    }
+    let str = configStr;
+    substitutionMap.forEach((value, key) => {
+      while(str.indexOf(key) > -1) {
+        str = str.replace(key, value);
+      }
+    });
+    return str;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,39 @@ export async function activate(context: vscode.ExtensionContext) {
   const log = new Log('cmakeExplorer', workspaceFolder, 'CMake Explorer Log');
   context.subscriptions.push(log);
 
+  const config = vscode.workspace.getConfiguration(
+    'cmakeExplorer',
+    workspaceFolder.uri
+  );
+
+  const awaitCmake = config.get<boolean>('cmakeIntegration') || false;
+
+  if (awaitCmake) {
+    let cmakeExtension = vscode.extensions.getExtension('ms-vscode.cmake-tools');
+    // Wait to install
+    if (!cmakeExtension) {
+      log.info(`CMake extension was not found, waiting until it is installed and enabled.`);
+      await new Promise((resolve) => {
+        vscode.extensions.onDidChange(() => {
+          cmakeExtension = vscode.extensions.getExtension('ms-vscode.cmake-tools');
+          if (cmakeExtension) resolve();
+        })
+      });
+    }
+    // Wait to activate
+    if (cmakeExtension && !cmakeExtension.isActive) {
+      log.info(`CMake extension is not activated, waiting until it activates.`);
+      await new Promise((resolve) => {
+        const check = () => {
+          if (!cmakeExtension) throw 'CMake extension still undefined'; // This shouldn't happen
+          if (cmakeExtension.isActive) return resolve();
+          setTimeout(check, 1000);
+        }
+        check();
+      });
+    }
+  }
+
   // get the Test Explorer extension
   const testExplorerExtension = vscode.extensions.getExtension<TestHub>(
     testExplorerExtensionId


### PR DESCRIPTION
Another feature we wanted was the ability to load tests from the appropriate folder when we switch the build type in the CMake extension. Currently, the `buildDir` setting only allows for a static value, and if config is generated in a directory dependent on the build type, we were having to manually change the setting to run the correct tests each time.

This branch adds a feature flagged integration with the CMake extension published by Microsoft (`ms-vscode.cmake-tools`). If `cmakeExplorer.cmakeIntegration` is set to `true`, the adapter will now wait for `ms-vscode.cmaketools` to be enabled and to activate, then look for variables in the string settings such as `buildDir` and `buildConfig` and replace them with the current environment's value. Currently, I've only configured this to replace:

- `${workspaceFolder}`
- `${buildType}`

But I've tried to write it so it's relatively extensible and the CMake extension provides a large number of other variables that may be useful to add in the future.

This enabled us to set `buildDir` to `src/build/${buildType}`, which keeps the test listing in step with the currently selected build type. 

I appreciate this is a slightly more niche use case compared to #7, so certainly won't be offended if you don't want to merge this back into the main repo!

As part of this, I needed to up the minimum version of VSCode, as [vscode.extensions.onDidChange](https://code.visualstudio.com/api/references/vscode-api#extensions) wasn't added until `v1.31.0`.

As with #7, I'm happy to see to any issues or tests that need to be fixed, so let me know!