### PR TITLE
Default to use cmake integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,19 +72,19 @@
         "cmakeExplorer.buildDir": {
           "description": "The CMake build directory (relative to the workspace folder)",
           "type": "string",
-          "default": "",
+          "default": "${buildDirectory}",
           "scope": "resource"
         },
         "cmakeExplorer.buildConfig": {
           "description": "The CMake build configuration (empty for any)",
           "type": "string",
-          "default": "",
+          "default": "${buildType}",
           "scope": "resource"
         },
         "cmakeExplorer.cmakeIntegration": {
           "description": "Integrate with the CMake Tools extension for additional variables",
           "type": "boolean",
-          "default": "false",
+          "default": "true",
           "scope": "resource"
         },
         "cmakeExplorer.debugConfig": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,15 +34,13 @@ export async function activate(context: vscode.ExtensionContext) {
     );
     if (!cmakeExtension) {
       const message = `CMake integration is enabled but the CMake Tools extension is not installed`;
-      log.warn(
-        message
-      );
+      log.warn(message);
       vscode.window.showErrorMessage(message);
     } else if (!cmakeExtension.isActive) {
       log.warn(
         `CMake integration is enabled but the CMake Tools extension is not active`
       );
-      cmakeExtension.activate();
+      await cmakeExtension.activate();
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,13 +33,16 @@ export async function activate(context: vscode.ExtensionContext) {
       'ms-vscode.cmake-tools'
     );
     if (!cmakeExtension) {
+      const message = `CMake integration is enabled but the CMake Tools extension is not installed`;
       log.warn(
-        `CMake integration is enabled but the CMake Tools extension is not installed`
+        message
       );
+      vscode.window.showErrorMessage(message);
     } else if (!cmakeExtension.isActive) {
       log.warn(
         `CMake integration is enabled but the CMake Tools extension is not active`
       );
+      cmakeExtension.activate();
     }
   }
 


### PR DESCRIPTION
Also automatic activate cmake-tool if it's present.

If there is an api to automatically download other extension, like automatically download cmake-tool, it would be even better.