### PR TITLE
Allow test names with spaces in start/pass/fail regexes

### DIFF
--- a/src/cmake-runner.ts
+++ b/src/cmake-runner.ts
@@ -20,17 +20,17 @@ const CMAKE_CACHE_FILE = 'CMakeCache.txt';
 const CTEST_RE = /^CMAKE_CTEST_COMMAND:INTERNAL=(.*)$/m;
 
 /** Regexp for test start line */
-const CTEST_START_RE = /^\s+Start\s+(\d+): (\S+)/;
+const CTEST_START_RE = /^\s+Start\s+(\d+): (.+)/;
 
 /** Regexp for test output line */
 const CTEST_OUTPUT_RE = /^(\d+): .*$/;
 
 /** Regexp for test passed line */
-const CTEST_PASSED_RE = /^\s*\d+\/\d+ Test\s+#(\d+): (\S+).*\.\.\.+   Passed/;
+const CTEST_PASSED_RE = /^\s*\d+\/\d+ Test\s+#(\d+): (.+) \.\.\.+   Passed/;
 
 /** Regexp for test failed line */
 const CTEST_FAILED_RE =
-  /^\s*\d+\/\d+ Test\s+#(\d+): (\S+).*\.\.\.+\*\*\*/;
+  /^\s*\d+\/\d+ Test\s+#(\d+): (.+) \.\.\.+\*\*\*/;
 
 /** Generic test event */
 export type CmakeTestEvent =


### PR DESCRIPTION
This resolves issue #51 for my test cases ([barometz/cmake-tx-repro](https://github.com/barometz/cmake-tx-repro)), but I imagine the regexes were the way they were for a reason. If you have a list of CMake output this would need to be able to match, I'll happily take some time to massage the regexes to something more precise.

In the end, the "correct" solution would probably to add structured test result output to CTest.

![image](https://user-images.githubusercontent.com/691020/155882390-46d7efa7-91f1-4862-8875-c67f19543197.png)
