### PR TITLE
Add support for reporting skipped tests

### DIFF
--- a/src/cmake-adapter.ts
+++ b/src/cmake-adapter.ts
@@ -341,7 +341,7 @@ export class CmakeAdapter implements TestAdapter {
               this.testStatesEmitter.fire(<TestEvent>{
                 type: 'test',
                 test: event.name,
-                state: event.success ? 'passed' : 'failed',
+                state: event.state,
                 message,
               });
               break;


### PR DESCRIPTION
I was displeased to see that unit tests that are skipped were being reported as being failed. A skipped test is not failed, and shouldn't be displayed as such. I investigated and saw that the Test Explorer UI had support for showing skipped tests as such, but this adapter just wasn't reporting them as such. This pull request adds that detection and reporting of the skipped status.